### PR TITLE
TRPL2 second-edition-jaブランチのgit checkoutコマンドを修正（その２）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           working_directory: ~/trpl2
       - run:
           name: Checking out a branch on TRPL2
-          command: git checkout second-edition-ja
+          command: git checkout -b second-edition-ja origin/second-edition-ja
           working_directory: ~/trpl2/book
       - run:
           name: Removing blank lines and HTML comments from SUMMARY.md


### PR DESCRIPTION
Circle CIのbuild_trpl2ジョブを修正し、TRPL2のsecond-edition-jaブランチがcheckoutできるようにする。

#4 が失敗に終わったので、再度の修正となる。失敗した原因はCIコンテナにssh接続して確認済み。master-jaブランチにsecond-edition-jaブランチと同じ名前の移行用ディレクトリがあることが原因だった。`git checkout`コマンドを修正することで対応する。