### PR TITLE
mdBookをアップグレード（fork版の0.1.9 + CVE-2020-26297の修正）

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2
 jobs:
   build_trpl2:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:trpl2
+      - image: quay.io/rust-lang-ja/circleci:trpl2-2021-01-11
     parallelism: 1
     steps:
       - checkout


### PR DESCRIPTION
[TRPL 2](https://doc.rust-jp.rs/book/second-edition/) の生成に使用しているmdBookのバージョンを0.1.8から [私たちがforkしたmdBook](https://github.com/rust-lang-ja/mdBook) の0.1.9へアップデートします。理由は、mdBook 0.4.5より前のバージョンで生成したサイトの検索機能にセキュリティーの脆弱性があるためです。私たちの0.1.9にはそれに対する [修正コミット](https://github.com/rust-lang-ja/mdBook/commit/3bb522d8f10e890f9dd6f0250776584810a78cfe) が入っています（`git cherry-pick`を使用）

脆弱性の詳細：
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26297
- https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html